### PR TITLE
大佬，发现您的项目引入了com.mchange:c3p0@0.9.5.1组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.javaworld</groupId>
 	<artifactId>code-snippet</artifactId>
@@ -10,7 +9,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>2.5.2</version>
-		<relativePath /> <!-- lookup parent from repository -->
+		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
 	<dependencies>
@@ -67,7 +66,7 @@
 		<dependency>
 			<groupId>com.mchange</groupId>
 			<artifactId>c3p0</artifactId>
-			<version>0.9.5.1</version>
+			<version>0.9.5.4</version>
 		</dependency>
 
 


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：c3p0 跨站脚本漏洞
缺陷组件：com.mchange:c3p0@0.9.5.1
漏洞编号：CVE-2018-20433
漏洞描述：c3p0是一款支持高并发的开源JDBC连接池库。
c3p0 0.9.5.2版本中com/mchange/v2/c3p0/cfg/C3P0ConfigXmlUtils.java文件的extractXmlConfigFromInputStream存在跨站脚本漏洞。远程攻击者可利用该漏洞注入任意的Web脚本或THML。
影响范围：(∞, 0.9.5.3)
最小修复版本：0.9.5.4
缺陷组件引入路径：org.javaworld:code-snippet@0.0.1-SNAPSHOT->com.mchange:c3p0@0.9.5.1
```
另外我运行这个项目时，IDE的安全插件提示还有5个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pc6ac2